### PR TITLE
Fix font paths

### DIFF
--- a/src/main/java/gutenberg/itext/pegdown/JLaTeXmathFontMapper.java
+++ b/src/main/java/gutenberg/itext/pegdown/JLaTeXmathFontMapper.java
@@ -62,7 +62,7 @@ public class JLaTeXmathFontMapper implements FontMapper {
             String name = basePath + fontName + ".ttf";
             InputStream stream = getClass().getResourceAsStream(name);
             if (stream != null)
-                 return stream;
+                return stream;
         }
         return null;
     }

--- a/src/main/java/gutenberg/itext/pegdown/JLaTeXmathFontMapper.java
+++ b/src/main/java/gutenberg/itext/pegdown/JLaTeXmathFontMapper.java
@@ -52,15 +52,17 @@ public class JLaTeXmathFontMapper implements FontMapper {
     private InputStream openStream(String fontName) {
         for (String basePath : Arrays.asList(
                 "/org/scilab/forge/jlatexmath/fonts/maths/",
-                "/org/scilab/forge/jlatexmath/fonts/maths/optional",
+                "/org/scilab/forge/jlatexmath/fonts/maths/optional/",
                 "/org/scilab/forge/jlatexmath/fonts/latin/",
-                "/org/scilab/forge/jlatexmath/fonts/latin/optional",
+                "/org/scilab/forge/jlatexmath/fonts/latin/optional/",
                 "/org/scilab/forge/jlatexmath/fonts/base/",
-                "/org/scilab/forge/jlatexmath/fonts/euler/")) {
+                "/org/scilab/forge/jlatexmath/fonts/euler/",
+                "/org/scilab/forge/jlatexmath/cyrillic/fonts/",
+                "/org/scilab/forge/jlatexmath/greek/fonts/")) {
             String name = basePath + fontName + ".ttf";
             InputStream stream = getClass().getResourceAsStream(name);
             if (stream != null)
-                return stream;
+                 return stream;
         }
         return null;
     }


### PR DESCRIPTION
Fixes issue when trying to render fonts to pdf due to wrong (without slash before the filename) or missing path to the font within the JLaTeXMath library.
This issue was for example occurring when rendering a latex-expression including \bf{bold text}